### PR TITLE
Update supported pseudo parameters

### DIFF
--- a/lib/cfndsl.rb
+++ b/lib/cfndsl.rb
@@ -392,7 +392,12 @@ module CfnDsl
       puts self.to_json  # uncomment for pretty printing # {:space => ' ', :indent => '  ', :object_nl => "\n", :array_nl => "\n" }
     end
 
-    @@globalRefs = { "AWS::Region" => 1 }
+    @@globalRefs = { 
+       "AWS::NotificationARNs" => 1, 
+       "AWS::Region" => 1,
+       "AWS::StackId" => 1,
+       "AWS::StackName" => 1
+    }
 
     def isValidRef( ref, origin=nil)
       ref = ref.to_s


### PR DESCRIPTION
Extended list of pseudo parameters listed in http://docs.amazonwebservices.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html

Allows `Ref("AWS::StackName")` and other...
