### PR TITLE
Clean up the Listener property type

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -324,7 +324,7 @@ Resources:
     ResourceRecords: [ String ]
     Weight: Integer
     SetIdentifier: String
-    AliasTarget: String
+    AliasTarget: [ AliasTarget ]
     Comment: String
   "AWS::Route53::RecordSetGroup" :
    Properties:


### PR DESCRIPTION
Add InstanceProtocol property to the LoadBalancer Listener property type
Changed SSLCertificate to SSLCertificateId in the Listener property type.

see: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-listener.html
