### PR TITLE
Changing AliasTarget property to be a single AliasTarget, and not an array of them.

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -324,7 +324,7 @@ Resources:
     ResourceRecords: [ String ]
     Weight: Integer
     SetIdentifier: String
-    AliasTarget: [ AliasTarget ]
+    AliasTarget: AliasTarget
     Comment: String
   "AWS::Route53::RecordSetGroup" :
    Properties:


### PR DESCRIPTION
Fixing bug I introduced in 308e86. 
