### PR TITLE
Fixed incomplete 'GroupName' property for AWS::IAM::UserToGroupAddition

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -261,7 +261,7 @@ Resources:
     Users: [ String ]
   "AWS::IAM::UserToGroupAddition" :
    Properties:
-    Group: String
+    GroupName: String
     Users: [String]
   "AWS::IAM::User" :
    Properties:


### PR DESCRIPTION
See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-addusertogroup.html
