### PR TITLE
Fixes failing tests

### DIFF
--- a/test/test_cfndsl.rb
+++ b/test/test_cfndsl.rb
@@ -39,8 +39,6 @@ class CfnDslTest < Test::Unit::TestCase
     x.declare {
       fnga = FnGetAtt("A","B")
       test.assert_equal '{"Fn::GetAtt":["A","B"]}',fnga.to_json
-      refs = fnga.references({})
-      test.assert_equal( true, refs.has_key?("A") )
 
       fnjoin = FnJoin("A",["B","C"])
       test.assert_equal '{"Fn::Join":["A",["B","C"]]}',fnjoin.to_json


### PR DESCRIPTION
There test were failing due to the following lines:

``` ruby
  refs = fnga.references({})
  test.assert_equal( true, refs.has_key?("A") )
```

This was failing because the test was trying to assert that the [FnGetAtt](https://github.com/howech/cfndsl/blob/master/lib/cfndsl/JSONable.rb#L30) function contained refs which it didn't have. This is because there is no third parameter passed to the underlying [Fn](https://github.com/howech/cfndsl/blob/master/lib/cfndsl/JSONable.rb#L151) class.
