### PR TITLE
Don't exit - write error to STDERR

### DIFF
--- a/lib/cfndsl.rb
+++ b/lib/cfndsl.rb
@@ -19,12 +19,11 @@ def CloudFormation(&block)
   x.declare(&block)
   invalid_references = x.checkRefs()
   if( invalid_references ) then
-    $stderr.puts invalid_references.join("\n");
+    abort invalid_references.join("\n")
   elsif( CfnDsl::Errors.errors? ) then
-    CfnDsl::Errors.report
+    abort CfnDsl::Errors.errors.join("\n")
   else
     x.generateOutput
   end
 end
-
 

--- a/lib/cfndsl/Errors.rb
+++ b/lib/cfndsl/Errors.rb
@@ -1,8 +1,8 @@
 module CfnDsl
   module Errors
     @@errors = []
-    
-    def self.error( err, idx=nil ) 
+
+    def self.error( err, idx=nil )
       if(idx.nil?) then
         @@errors.push ( err + "\n" + caller.join("\n") + "\n" )
       else
@@ -11,19 +11,17 @@ module CfnDsl
         else
           err_loc = caller[idx]
         end
-        
+
         @@errors.push ( err_loc + " " + err + "\n" )
       end
     end
-    
+
     def self.clear()
       @@errors = []
     end
 
-    def self.report() 
-      @@errors.each do |err|
-        puts err
-      end
+    def self.errors()
+      @@errors
     end
 
     def self.errors?()


### PR DESCRIPTION
The error outputting from the CLI tool is inconsistent.

This pr uses `abort` which prints to `STDERR` and exits with a code of 1 for both invalid references and errors in the template.
