### PR TITLE
changed TemplateURL to correct case.

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -58,7 +58,7 @@ Resources:
     LowerThreshold: String   
   "AWS::CloudFormation::Stack" :
    Properties:
-    TemplateUrl: String
+    TemplateURL: String
     TimeoutInMinutes: String
     Parameters: CloudFormationStackParameters
   "AWS::CloudFormation::WaitCondition" :


### PR DESCRIPTION
Amazon wamts "TemplateURL" not "TemplateUrl".
