### PR TITLE
Eval context

### DIFF
--- a/bin/cfndsl
+++ b/bin/cfndsl
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby 
 require 'cfndsl'
-model = eval File.read ARGV[0]
+filename = File.expand_path(ARGV[0])
+model = eval(File.read(filename), binding(), filename)
 puts model.to_json


### PR DESCRIPTION
This adds some context to the eval, so things like **FILE** will work, and so that error messages get generated referring to the correct file.
