### PR TITLE
Add support for ConnectionDrainingPolicy

### DIFF
--- a/lib/cfndsl/aws_types.yaml
+++ b/lib/cfndsl/aws_types.yaml
@@ -296,6 +296,7 @@ Resources:
     Scheme: String
     SecurityGroups: [ String ]
     Subnets: [ String ]
+    ConnectionDrainingPolicy: ConnectionDrainingPolicy
    Attributes:
     CanonicalHostedZoneName: String
     CanonicalGostedZoneNameID: String
@@ -531,6 +532,9 @@ Types:
   CookieName: String
   PolicyName: String
   CookieExpirationPeriod: String
+ ConnectionDrainingPolicy:
+  Enabled: Boolean
+  Timeout: Integer
  Listener:
   InstancePort: String
   InstanceProtocol: String


### PR DESCRIPTION
Adds the ConnectionDrainingPolicy type for AWS::EC2::LoadBalancer

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-connectiondrainingpolicy.html
