### PR TITLE
Allow passing of lambda instead of a block

### DIFF
--- a/lib/cfndsl/JSONable.rb
+++ b/lib/cfndsl/JSONable.rb
@@ -173,7 +173,11 @@ module CfnDsl
     end
 
     def declare(&block)
-      self.instance_eval &block if block_given?
+      begin
+        self.instance_eval block.call if block_given?
+      rescue => e
+        self.instance_eval &block if block_given?
+      end
     end
 
     def method_missing(meth,*args,&block)


### PR DESCRIPTION
This change is a dependency for https://github.com/BBC-News/bbc-cosmos-tools/pull/10 which has built an abstraction around CFNDSL and needs to pass a `lambda` in place of a proper `{}` block. 

We do this when calling:

``` rb
CfnDsl::CloudFormationTemplate.new.declare(&block)
```

Because of the way the original code worked, it would pass a block back to the `declare` method multiple times and after the first call all other blocks passed into the method were Procs wrapping an eval error. 

The original code would just handle this without triggering any errors, but when moving to a lambda a `#<TypeError: no implicit conversion of Array into String>` would be raised and so I had to rescue that error as shown in this commit
