### PR TITLE
cfndsl fix list type subproperties for LaunchSpecifications

### DIFF
--- a/lib/cfndsl/specification.rb
+++ b/lib/cfndsl/specification.rb
@@ -65,7 +65,8 @@ module CfnDsl
           elsif nested_prop_info['PrimitiveItemType']
             nested_prop_type = Array(nested_prop_info['PrimitiveItemType'])
           elsif nested_prop_info['ItemType']
-            nested_prop_type = root_resource_name + nested_prop_info['ItemType']
+            #nested_prop_type = root_resource_name + nested_prop_info['ItemType']
+            nested_prop_type = Array(root_resource_name + nested_prop_info['ItemType'])
           elsif nested_prop_info['Type']
             nested_prop_type = root_resource_name + nested_prop_info['Type']
           else

--- a/lib/cfndsl/specification.rb
+++ b/lib/cfndsl/specification.rb
@@ -65,7 +65,6 @@ module CfnDsl
           elsif nested_prop_info['PrimitiveItemType']
             nested_prop_type = Array(nested_prop_info['PrimitiveItemType'])
           elsif nested_prop_info['ItemType']
-            #nested_prop_type = root_resource_name + nested_prop_info['ItemType']
             nested_prop_type = Array(root_resource_name + nested_prop_info['ItemType'])
           elsif nested_prop_info['Type']
             nested_prop_type = root_resource_name + nested_prop_info['Type']

--- a/lib/cfndsl/types.rb
+++ b/lib/cfndsl/types.rb
@@ -82,7 +82,7 @@ module CfnDsl
                   if value.nil? && rest.empty? && block
                     val = klass.new
                     existing.push val
-                    value.instance_eval(&block(val))
+                    val.instance_eval(&block)
                     return existing
                   end
 


### PR DESCRIPTION
My use case for this was for 

```ruby
EC2_SpotFleet {
    SpotFleetRequestConfigData {
       #LaunchSpecification is a List of SpotFleetLaunchSpecification
       LaunchSpecification {
           ImageId 'ami-xxx'            
       }
    }
}
```