### PR TITLE
add a :hash params type, for use in programs calling cfndsl code directly

### DIFF
--- a/lib/cfndsl.rb
+++ b/lib/cfndsl.rb
@@ -52,6 +52,10 @@ module CfnDsl
   #         evaluated in the binding context, similar to the contents of
   #         a ruby file.
   #
+  # :hash - the second element is expected to be a ruby Hash. Each key becomes
+  #         a local variable in the evaluation context. This param is only
+  #         useful for programs calling CfnDsl directly.
+  #
   # Note that the order is important, as later extra sections can overwrite
   # or even undo things that were done by earlier sections.
 
@@ -65,6 +69,10 @@ module CfnDsl
         klass_name = type.to_s.upcase
         logstream.puts("Loading #{klass_name} file #{file}") if logstream
         params.load_file file
+        params.add_to_binding(b, logstream) unless disable_binding?
+      when :hash
+        logstream.puts("Merging hash #{file}") if logstream
+        params.merge(file)
         params.add_to_binding(b, logstream) unless disable_binding?
       when :ruby
         if disable_binding?

--- a/lib/cfndsl/external_parameters.rb
+++ b/lib/cfndsl/external_parameters.rb
@@ -61,6 +61,10 @@ module CfnDsl
       else
         raise "Unrecognized extension #{format}"
       end
+      merge(params)
+    end
+
+    def merge(params)
       if CfnDsl.disable_deep_merge?
         params.each { |key, val| set_param(key, val) }
       else

--- a/spec/external_parameters_spec.rb
+++ b/spec/external_parameters_spec.rb
@@ -85,6 +85,14 @@ describe CfnDsl::ExternalParameters do
     end
   end
 
+  context '#merge' do
+    it 'merges a hash into the parameters' do
+      subject.merge('foo' => 'bar', :baz => 'meh')
+      expect(subject[:foo]).to eq('bar')
+      expect(subject[:baz]).to eq('meh')
+    end
+  end
+
   context '#[]' do
     it 'accesses the parameters like a Hash' do
       expect(subject).to respond_to(:[])


### PR DESCRIPTION
This goes towards https://github.com/cfndsl/cfndsl/issues/255 and would fit my needs for calling cfndsl from other ruby programs where templates are regular files.

Yes, my program could make use of the `:raw` extra type and turn a hash into an array of `foo=bar` strings, but that's awkward.  :-)