### PR TITLE
Add missing ElasticSearch attributes

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -683,8 +683,10 @@ Resources:
     EBSOptions: EBSOptions
     ElasticsearchVersion: String
     ElasticsearchClusterConfig: ElasticsearchClusterConfig
+    EncryptionAtRestOptions: EncryptionAtRestOptions
     SnapshotOptions: SnapshotOptions
     Tags: [ ResourceTag ]
+    VPCOptions: VpcConfig
   "AWS::Events::Rule":
    Properties:
     Description: String
@@ -1559,6 +1561,9 @@ Types:
    InstanceCount: Integer
    InstanceType: String
    ZoneAwarenessEnabled: Boolean
+ EncryptionAtRestOptions:
+   Enabled: Boolean
+   KmsKeyId: String
  SnapshotOptions:
    AutomatedSnapshotStartHour: Integer
  RedrivePolicy:


### PR DESCRIPTION
This PR adds the VPC options required to run ElasticSearch inside a VPD and the EncryptionAtRest attribute.  With the addition of these two attributes, cfndsl now supports all attributes (for ES Domains) that CloudFormation itself supports.