### PR TITLE
offer option to 'lock' resource_specification.json version - Fix for #393

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,8 @@ Usage: cfndsl [options] FILE
     -b, --disable-binding            Disable binding configuration
     -m, --disable-deep-merge         Disable deep merging of yaml
     -s, --specification-file FILE    Location of Cloudformation Resource Specification file
-    -u, --update-specification       Update the Cloudformation Resource Specification file
+    -u [VERSION],                    Update the Resource Specification file to latest, or specific version
+        --update-specification
     -g RESOURCE_TYPE,RESOURCE_LOGICAL_NAME,
         --generate                   Add resource type and logical name
     -l, --list                       List supported resources

--- a/bin/cfndsl
+++ b/bin/cfndsl
@@ -97,10 +97,10 @@ if options[:update_spec]
   STDERR.puts 'Updating specification file'
   FileUtils.mkdir_p File.dirname(CfnDsl.specification_file)
   begin
-    content = open("https://d1uauaxba7bl26.cloudfront.net/#{options[:spec_version]}/CloudFormationResourceSpecification.json").read
+    content = open("https://d1uauaxba7bl26.cloudfront.net/#{options[:spec_version]}/gzip/CloudFormationResourceSpecification.json").read
   rescue OpenURI::HTTPError
     STDERR.puts "Resource Specification version #{options[:spec_version]} not found, defaulting to 'latest'"
-    content = open('https://d1uauaxba7bl26.cloudfront.net/latest/CloudFormationResourceSpecification.json').read
+    content = open('https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json').read
   end
   File.open(CfnDsl.specification_file, 'w') { |f| f.puts content }
   STDERR.puts "Specification successfully written to #{CfnDsl.specification_file}"

--- a/bin/cfndsl
+++ b/bin/cfndsl
@@ -64,8 +64,8 @@ optparse = OptionParser.new do |opts|
     CfnDsl.specification_file File.expand_path(file)
   end
 
-  opts.on('-u', '--update-specification [VERSION]', 'Update the Cloudformation Resource Specification file to latest, or specify a version') do |file|
-    options[:spec_version] = file || 'latest'
+  opts.on('-u', '--update-specification [VERSION]', 'Update the Resource Specification file to latest, or specific version') do |file|
+    options[:spec_version] = file || 'latest'.freeze
     options[:update_spec] = true
   end
 
@@ -98,9 +98,9 @@ if options[:update_spec]
   FileUtils.mkdir_p File.dirname(CfnDsl.specification_file)
   begin
     content = open("https://d1uauaxba7bl26.cloudfront.net/#{options[:spec_version]}/CloudFormationResourceSpecification.json").read
-  rescue OpenURI::HTTPError => ex
-    puts "Resource Specification version #{options[:spec_version]} not found, defaulting to 'latest'"
-    content = open("https://d1uauaxba7bl26.cloudfront.net/latest/CloudFormationResourceSpecification.json").read
+  rescue OpenURI::HTTPError
+    STDERR.puts "Resource Specification version #{options[:spec_version]} not found, defaulting to 'latest'"
+    content = open('https://d1uauaxba7bl26.cloudfront.net/latest/CloudFormationResourceSpecification.json').read
   end
   File.open(CfnDsl.specification_file, 'w') { |f| f.puts content }
   STDERR.puts "Specification successfully written to #{CfnDsl.specification_file}"

--- a/bin/cfndsl
+++ b/bin/cfndsl
@@ -64,7 +64,8 @@ optparse = OptionParser.new do |opts|
     CfnDsl.specification_file File.expand_path(file)
   end
 
-  opts.on('-u', '--update-specification', 'Update the Cloudformation Resource Specification file') do
+  opts.on('-u', '--update-specification [VERSION]', 'Update the Cloudformation Resource Specification file to latest, or specify a version') do |file|
+    options[:spec_version] = file || 'latest'
     options[:update_spec] = true
   end
 
@@ -95,7 +96,12 @@ optparse.parse!
 if options[:update_spec]
   STDERR.puts 'Updating specification file'
   FileUtils.mkdir_p File.dirname(CfnDsl.specification_file)
-  content = open('https://d1uauaxba7bl26.cloudfront.net/latest/CloudFormationResourceSpecification.json').read
+  begin
+    content = open("https://d1uauaxba7bl26.cloudfront.net/#{options[:spec_version]}/CloudFormationResourceSpecification.json").read
+  rescue OpenURI::HTTPError => ex
+    puts "Resource Specification version #{options[:spec_version]} not found, defaulting to 'latest'"
+    content = open("https://d1uauaxba7bl26.cloudfront.net/latest/CloudFormationResourceSpecification.json").read
+  end
   File.open(CfnDsl.specification_file, 'w') { |f| f.puts content }
   STDERR.puts "Specification successfully written to #{CfnDsl.specification_file}"
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -15,7 +15,8 @@ describe 'cfndsl', type: :aruba do
           -b, --disable-binding            Disable binding configuration
           -m, --disable-deep-merge         Disable deep merging of yaml
           -s, --specification-file FILE    Location of Cloudformation Resource Specification file
-          -u, --update-specification       Update the Cloudformation Resource Specification file
+          -u [VERSION],                    Update the Cloudformation Resource Specification file to latest, or specify a version
+              --update-specification
           -g RESOURCE_TYPE,RESOURCE_LOGICAL_NAME,
               --generate                   Add resource type and logical name
           -a, --assetversion               Print out the specification version

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+WORKING_SPEC_VERSION = '2.19.0'.freeze
+
 describe 'cfndsl', type: :aruba do
   let(:usage) do
     <<-USAGE.gsub(/^ {6}/, '').chomp
@@ -15,7 +17,7 @@ describe 'cfndsl', type: :aruba do
           -b, --disable-binding            Disable binding configuration
           -m, --disable-deep-merge         Disable deep merging of yaml
           -s, --specification-file FILE    Location of Cloudformation Resource Specification file
-          -u [VERSION],                    Update the Cloudformation Resource Specification file to latest, or specify a version
+          -u [VERSION],                    Update the Resource Specification file to latest, or specific version
               --update-specification
           -g RESOURCE_TYPE,RESOURCE_LOGICAL_NAME,
               --generate                   Add resource type and logical name
@@ -35,9 +37,9 @@ describe 'cfndsl', type: :aruba do
 
   before(:each) { write_file('template.rb', template_content) }
 
-  context 'cfndsl -u' do
+  context "cfndsl -u #{WORKING_SPEC_VERSION}" do
     it 'updates the specification file' do
-      run 'cfndsl -u'
+      run_command "cfndsl -u #{WORKING_SPEC_VERSION}"
       expect(last_command_started).to have_output_on_stderr(<<-OUTPUT.gsub(/^ {8}/, '').chomp)
         Updating specification file
         Specification successfully written to #{ENV['HOME']}/.cfndsl/resource_specification.json
@@ -48,7 +50,7 @@ describe 'cfndsl', type: :aruba do
 
   context 'cfndsl -a' do
     it 'prints out the specification file version' do
-      run 'cfndsl -a'
+      run_command 'cfndsl -a'
       expect(last_command_started).to have_output_on_stderr(/([0-9]+\.){2}[0-9]+/)
       expect(last_command_started).to have_exit_status(0)
     end
@@ -56,7 +58,7 @@ describe 'cfndsl', type: :aruba do
 
   context 'cfndsl' do
     it 'displays the usage' do
-      run 'cfndsl'
+      run_command 'cfndsl'
       expect(last_command_started).to have_output(usage)
       expect(last_command_started).to have_exit_status(1)
     end
@@ -64,14 +66,14 @@ describe 'cfndsl', type: :aruba do
 
   context 'cfndsl --help' do
     it 'displays the usage' do
-      run_simple 'cfndsl --help'
+      run_command_and_stop 'cfndsl --help'
       expect(last_command_started).to have_output(usage)
     end
   end
 
   context 'cfndsl FILE' do
     it 'gives a deprecation warning about bindings' do
-      run_simple 'cfndsl template.rb'
+      run_command_and_stop 'cfndsl template.rb'
       expect(last_command_started).to have_output_on_stderr(<<-WARN.gsub(/^ {8}/, '').chomp)
         The creation of constants as config is deprecated!
         Please switch to the #external_parameters method within your templates to access variables
@@ -81,14 +83,14 @@ describe 'cfndsl', type: :aruba do
     end
 
     it 'generates a JSON CloudFormation template' do
-      run_simple 'cfndsl template.rb'
+      run_command_and_stop 'cfndsl template.rb'
       expect(last_command_started).to have_output_on_stdout('{"AWSTemplateFormatVersion":"2010-09-09","Description":"default"}')
     end
   end
 
   context 'cfndsl FILE --pretty' do
     it 'generates a pretty JSON CloudFormation template' do
-      run_simple 'cfndsl template.rb --pretty'
+      run_command_and_stop 'cfndsl template.rb --pretty'
       expect(last_command_started).to have_output_on_stdout(<<-OUTPUT.gsub(/^ {8}/, '').chomp)
         {
           "AWSTemplateFormatVersion": "2010-09-09",
@@ -100,7 +102,7 @@ describe 'cfndsl', type: :aruba do
 
   context 'cfndsl FILE --output FILE' do
     it 'writes the JSON CloudFormation template to a file' do
-      run_simple 'cfndsl template.rb --output template.json'
+      run_command_and_stop 'cfndsl template.rb --output template.json'
       expect(read('template.json')).to eq(['{"AWSTemplateFormatVersion":"2010-09-09","Description":"default"}'])
     end
   end
@@ -109,7 +111,7 @@ describe 'cfndsl', type: :aruba do
     before { write_file('params.yaml', 'DESC: yaml') }
 
     it 'interpolates the YAML file in the CloudFormation template' do
-      run_simple 'cfndsl template.rb --yaml params.yaml'
+      run_command_and_stop 'cfndsl template.rb --yaml params.yaml'
       expect(last_command_started).to have_output_on_stdout('{"AWSTemplateFormatVersion":"2010-09-09","Description":"yaml"}')
     end
   end
@@ -118,7 +120,7 @@ describe 'cfndsl', type: :aruba do
     before { write_file('params.json', '{"DESC":"json"}') }
 
     it 'interpolates the JSON file in the CloudFormation template' do
-      run_simple 'cfndsl template.rb --json params.json'
+      run_command_and_stop 'cfndsl template.rb --json params.json'
       expect(last_command_started).to have_output_on_stdout('{"AWSTemplateFormatVersion":"2010-09-09","Description":"json"}')
     end
   end
@@ -136,12 +138,12 @@ describe 'cfndsl', type: :aruba do
     before(:each) { write_file('params.rb', 'DESC = "ruby"') }
 
     it 'interpolates the Ruby file in the CloudFormation template' do
-      run_simple 'cfndsl template.rb --ruby params.rb'
+      run_command_and_stop 'cfndsl template.rb --ruby params.rb'
       expect(last_command_started).to have_output_on_stdout('{"AWSTemplateFormatVersion":"2010-09-09","Description":"ruby"}')
     end
 
     it 'gives a deprecation warning and does not interpolate if bindings are disabled' do
-      run_simple 'cfndsl template.rb --ruby params.rb --disable-binding --verbose'
+      run_command_and_stop 'cfndsl template.rb --ruby params.rb --disable-binding --verbose'
       deprecation_warning = /Interpreting Ruby files was disabled\. .*params.rb will not be read/
       expect(last_command_started).to have_output_on_stderr(deprecation_warning)
       expect(last_command_started).to have_output_on_stdout('{"AWSTemplateFormatVersion":"2010-09-09","Description":"default"}')
@@ -150,7 +152,7 @@ describe 'cfndsl', type: :aruba do
 
   context 'cfndsl FILE --define VARIABLE=VALUE' do
     it 'interpolates the command line variables in the CloudFormation template' do
-      run "cfndsl template.rb --define \"DESC='cli'\""
+      run_command "cfndsl template.rb --define \"DESC='cli'\""
       expect(last_command_started).to have_output_on_stdout("{\"AWSTemplateFormatVersion\":\"2010-09-09\",\"Description\":\"'cli'\"}")
     end
   end
@@ -159,7 +161,7 @@ describe 'cfndsl', type: :aruba do
     before { write_file('params.yaml', 'DESC: yaml') }
 
     it 'displays the variables as they are interpolated in the CloudFormation template' do
-      run_simple 'cfndsl template.rb --yaml params.yaml --verbose'
+      run_command_and_stop 'cfndsl template.rb --yaml params.yaml --verbose'
       verbose = /
         Using \s specification \s file .* \.json \n
         Loading \s YAML \s file \s .* params\.yaml \n


### PR DESCRIPTION
running "cfndsl -u" still works as it always has, however specifying a version, will retrieve that particular release of the resource_specification.json file, thus:

"cfndsl -u 2.21.0", thus it's possible to "lock" a particular codebase/pipeline with a known-working version of the resource json file, rather than defaulting to the (sometimes broken) version of the file, by downloading the latest.