### PR TITLE
handle simple resource types

### DIFF
--- a/lib/cfndsl/specification.rb
+++ b/lib/cfndsl/specification.rb
@@ -38,7 +38,7 @@ module CfnDsl
     end
     # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
 
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     def self.extract_types(spec)
       primitive_types = {
         'String' => 'String',
@@ -58,31 +58,36 @@ module CfnDsl
         root_resource = property_name.match(/(.*)\./)
         root_resource_name = root_resource ? root_resource[1].gsub(/::/, '') : property_name
         property_name = property_name.gsub(/::|\./, '')
-        next unless property_info['Properties']
 
-        properties = property_info['Properties'].each_with_object({}) do |(nested_prop_name, nested_prop_info), extracted|
-          if nested_prop_info['Type'] == 'Map' || nested_prop_info['Type'] == 'Json'
-            # The Map type and the incorrectly labelled Json type
-            nested_prop_type = 'Json'
-          elsif nested_prop_info['PrimitiveType']
-            nested_prop_type = nested_prop_info['PrimitiveType']
-          elsif nested_prop_info['PrimitiveItemType']
-            nested_prop_type = Array(nested_prop_info['PrimitiveItemType'])
-          elsif nested_prop_info['ItemType']
-            nested_prop_type = Array(root_resource_name + nested_prop_info['ItemType'])
-          elsif nested_prop_info['Type']
-            nested_prop_type = root_resource_name + nested_prop_info['Type']
-          else
-            warn "could not extract type from #{property_name}"
+        if property_info.key?('PrimitiveType')
+          properties = property_info['PrimitiveType']
+        elsif property_info.key?('Type')
+          properties = property_info['Type']
+        elsif property_info.key?('Properties')
+          properties = property_info['Properties'].each_with_object({}) do |(nested_prop_name, nested_prop_info), extracted|
+            if nested_prop_info['Type'] == 'Map' || nested_prop_info['Type'] == 'Json'
+              # The Map type and the incorrectly labelled Json type
+              nested_prop_type = 'Json'
+            elsif nested_prop_info['PrimitiveType']
+              nested_prop_type = nested_prop_info['PrimitiveType']
+            elsif nested_prop_info['PrimitiveItemType']
+              nested_prop_type = Array(nested_prop_info['PrimitiveItemType'])
+            elsif nested_prop_info['ItemType']
+              nested_prop_type = Array(root_resource_name + nested_prop_info['ItemType'])
+            elsif nested_prop_info['Type']
+              nested_prop_type = root_resource_name + nested_prop_info['Type']
+            else
+              warn "could not extract type from #{property_name}"
+            end
+            extracted[nested_prop_name] = nested_prop_type
+            extracted
           end
-          extracted[nested_prop_name] = nested_prop_type
-          extracted
         end
         types[property_name] = properties
         types
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 
     def self.determine_spec_file
       return CfnDsl.specification_file if File.exist? CfnDsl.specification_file


### PR DESCRIPTION
Resource types have become simple, e.g.:
```
    "AWS::CodeBuild::Project.FilterGroup": {
      "Type": "List",
      "Required": false,
      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-filtergroup.html",
      "ItemType": "WebhookFilter",
      "UpdateType": "Mutable"
    },
```
and
```
    "AWS::EC2::LaunchTemplate.CapacityReservationPreference": {
      "PrimitiveType": "String"
    },
```

Before they would look like:
```
    "AWS::CodePipeline::CustomActionType.ArtifactDetails": {
      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-customactiontype-artifactdetails.html",
      "Properties": {
        ...
```