### PR TITLE
Fix rubocop offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'cfndsl/version'

--- a/bin/cfndsl
+++ b/bin/cfndsl
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'cfndsl/globals'
 require 'cfndsl/version'
@@ -65,7 +66,7 @@ optparse = OptionParser.new do |opts|
   end
 
   opts.on('-u', '--update-specification [VERSION]', 'Update the Resource Specification file to latest, or specific version') do |file|
-    options[:spec_version] = file || 'latest'.freeze
+    options[:spec_version] = file || 'latest'
     options[:update_spec] = true
   end
 
@@ -94,21 +95,21 @@ end
 optparse.parse!
 
 if options[:update_spec]
-  STDERR.puts 'Updating specification file'
+  warn 'Updating specification file'
   FileUtils.mkdir_p File.dirname(CfnDsl.specification_file)
   begin
     content = open("https://d1uauaxba7bl26.cloudfront.net/#{options[:spec_version]}/gzip/CloudFormationResourceSpecification.json").read
   rescue OpenURI::HTTPError
-    STDERR.puts "Resource Specification version #{options[:spec_version]} not found, defaulting to 'latest'"
+    warn "Resource Specification version #{options[:spec_version]} not found, defaulting to 'latest'"
     content = open('https://d1uauaxba7bl26.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json').read
   end
   File.open(CfnDsl.specification_file, 'w') { |f| f.puts content }
-  STDERR.puts "Specification successfully written to #{CfnDsl.specification_file}"
+  warn "Specification successfully written to #{CfnDsl.specification_file}"
 end
 
 if options[:assetversion]
   spec_file = JSON.parse File.read(CfnDsl.specification_file)
-  STDERR.puts spec_file['ResourceSpecificationVersion']
+  warn spec_file['ResourceSpecificationVersion']
 end
 
 if options[:lego]
@@ -129,7 +130,7 @@ filename = File.expand_path(ARGV[0])
 verbose = options[:verbose] && STDERR
 
 unless CfnDsl.disable_binding?
-  STDERR.puts <<-MSG.gsub(/^\s*/, '')
+  warn <<-MSG.gsub(/^\s*/, '')
     The creation of constants as config is deprecated!
     Please switch to the #external_parameters method within your templates to access variables
     See https://github.com/cfndsl/cfndsl/issues/170
@@ -137,7 +138,7 @@ unless CfnDsl.disable_binding?
   MSG
 end
 
-verbose.puts "Using specification file #{CfnDsl.specification_file}" if verbose
+verbose&.puts "Using specification file #{CfnDsl.specification_file}"
 
 require 'cfndsl'
 
@@ -145,7 +146,7 @@ model = CfnDsl.eval_file_with_extras(filename, options[:extras], verbose)
 
 output = STDOUT
 if options[:output] != '-'
-  verbose.puts("Writing to #{options[:output]}") if verbose
+  verbose&.puts("Writing to #{options[:output]}")
   output = File.open(File.expand_path(options[:output]), 'w')
 elsif verbose
   verbose.puts('Writing to STDOUT')

--- a/cfndsl.gemspec
+++ b/cfndsl.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'cfndsl/version'

--- a/lib/cfndsl.rb
+++ b/lib/cfndsl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 require 'json'
 

--- a/lib/cfndsl/aws/cloud_formation_template.rb
+++ b/lib/cfndsl/aws/cloud_formation_template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/orchestration_template'
 
 module CfnDsl

--- a/lib/cfndsl/aws/types.rb
+++ b/lib/cfndsl/aws/types.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'cfndsl/types'
 
 module CfnDsl
   module AWS
     # Cloud Formation Types
     module Types
-      TYPE_PREFIX = 'aws'.freeze
+      TYPE_PREFIX = 'aws'
       class Type < JSONable; end
       include CfnDsl::Types
     end

--- a/lib/cfndsl/conditions.rb
+++ b/lib/cfndsl/conditions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/jsonable'
 
 module CfnDsl

--- a/lib/cfndsl/creation_policy.rb
+++ b/lib/cfndsl/creation_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/jsonable'
 
 module CfnDsl

--- a/lib/cfndsl/errors.rb
+++ b/lib/cfndsl/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CfnDsl
   # Keeps track of errors
   module Errors

--- a/lib/cfndsl/external_parameters.rb
+++ b/lib/cfndsl/external_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CfnDsl
   # Handles all external parameters
   class ExternalParameters
@@ -46,7 +48,7 @@ module CfnDsl
 
     def add_to_binding(bind, logstream)
       parameters.each_pair do |key, val|
-        logstream.puts("Setting local variable #{key} to #{val}") if logstream
+        logstream&.puts("Setting local variable #{key} to #{val}")
         bind.eval "#{key} = #{val.inspect}"
       end
     end

--- a/lib/cfndsl/globals.rb
+++ b/lib/cfndsl/globals.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Global variables to adjust CfnDsl behavior
 module CfnDsl
   module_function

--- a/lib/cfndsl/json_serialisable_object.rb
+++ b/lib/cfndsl/json_serialisable_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CfnDsl
   # JSONSerialisableObject
   module JSONSerialisableObject

--- a/lib/cfndsl/jsonable.rb
+++ b/lib/cfndsl/jsonable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/errors'
 require 'cfndsl/ref_check'
 require 'cfndsl/json_serialisable_object'

--- a/lib/cfndsl/mappings.rb
+++ b/lib/cfndsl/mappings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/jsonable'
 
 module CfnDsl

--- a/lib/cfndsl/module.rb
+++ b/lib/cfndsl/module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/plurals'
 require 'cfndsl/names'
 

--- a/lib/cfndsl/names.rb
+++ b/lib/cfndsl/names.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Method name helper
 module CfnDsl
   module_function

--- a/lib/cfndsl/orchestration_template.rb
+++ b/lib/cfndsl/orchestration_template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/jsonable'
 require 'cfndsl/names'
 require 'cfndsl/aws/types'
@@ -121,7 +123,7 @@ module CfnDsl
 
       return true if GLOBAL_REFS.key?(ref)
 
-      return true if @Parameters && @Parameters.key?(ref)
+      return true if @Parameters&.key?(ref)
 
       return !origin || !@_resource_refs || !@_resource_refs[ref] || !@_resource_refs[ref].key?(origin) if @Resources.key?(ref)
 

--- a/lib/cfndsl/os/heat_template.rb
+++ b/lib/cfndsl/os/heat_template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/orchestration_template'
 
 module CfnDsl

--- a/lib/cfndsl/os/types.rb
+++ b/lib/cfndsl/os/types.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'cfndsl/types'
 
 module CfnDsl
   module OS
     # Open Stack Types
     module Types
-      TYPE_PREFIX = 'os'.freeze
+      TYPE_PREFIX = 'os'
       class Type < JSONable; end
       include CfnDsl::Types
     end

--- a/lib/cfndsl/outputs.rb
+++ b/lib/cfndsl/outputs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/jsonable'
 
 module CfnDsl

--- a/lib/cfndsl/parameters.rb
+++ b/lib/cfndsl/parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/jsonable'
 
 module CfnDsl

--- a/lib/cfndsl/patches.rb
+++ b/lib/cfndsl/patches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CfnDsl
   # Module for handling inconsistencies in the published resource specification from AWS
   # rubocop:disable Metrics/ModuleLength

--- a/lib/cfndsl/plurals.rb
+++ b/lib/cfndsl/plurals.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CfnDsl
   # Plural names for lists of content objects
   module Plurals

--- a/lib/cfndsl/properties.rb
+++ b/lib/cfndsl/properties.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/jsonable'
 
 module CfnDsl

--- a/lib/cfndsl/rake_task.rb
+++ b/lib/cfndsl/rake_task.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake'
 require 'rake/tasklib'
 
@@ -35,7 +37,7 @@ module CfnDsl
 
     def log(opts)
       type = opts[:output].nil? ? 'STDOUT' : opts[:output]
-      verbose.puts("Writing to #{type}") if verbose
+      verbose&.puts("Writing to #{type}")
     end
 
     def outputter(opts)
@@ -45,7 +47,7 @@ module CfnDsl
     def model(filename)
       raise "#{filename} doesn't exist" unless File.exist?(filename)
 
-      verbose.puts("using extras #{extra}") if verbose
+      verbose&.puts("using extras #{extra}")
       CfnDsl.eval_file_with_extras(filename, extra, verbose)
     end
 

--- a/lib/cfndsl/ref_check.rb
+++ b/lib/cfndsl/ref_check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This module defines some methods for walking the reference tree
 # of various objects.
 module RefCheck

--- a/lib/cfndsl/resources.rb
+++ b/lib/cfndsl/resources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/jsonable'
 require 'cfndsl/properties'
 require 'cfndsl/update_policy'

--- a/lib/cfndsl/specification.rb
+++ b/lib/cfndsl/specification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CfnDsl
   # Helper module for bridging the gap between a static types file included in the repo
   # and dynamically generating the types directly from the AWS specification

--- a/lib/cfndsl/types.rb
+++ b/lib/cfndsl/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 require 'cfndsl/jsonable'
 require 'cfndsl/plurals'

--- a/lib/cfndsl/update_policy.rb
+++ b/lib/cfndsl/update_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl/jsonable'
 
 module CfnDsl

--- a/lib/cfndsl/version.rb
+++ b/lib/cfndsl/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CfnDsl
-  VERSION = '0.16.13'.freeze
+  VERSION = '0.16.13'
 end

--- a/lib/cfnlego.rb
+++ b/lib/cfnlego.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 require 'erb'
 require 'cfnlego/cloudformation'

--- a/lib/cfnlego/cloudformation.rb
+++ b/lib/cfnlego/cloudformation.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 # Cfnlego
 module Cfnlego
   # CloudFormation
   class CloudFormation
-    TEMPLATE = "#{File.dirname(__FILE__)}/cloudformation.erb".freeze
+    TEMPLATE = "#{File.dirname(__FILE__)}/cloudformation.erb"
 
     attr_reader :resources
 

--- a/lib/cfnlego/resource.rb
+++ b/lib/cfnlego/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 require 'net/http'
 require 'uri'

--- a/lib/deep_merge/core.rb
+++ b/lib/deep_merge/core.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/AbcSize, Metrics/BlockNesting, Metrics/CyclomaticComplexity, Metrics/MethodLength
 # rubocop:disable Metrics/ModuleLength, Metrics/PerceivedComplexity, Style/IfInsideElse, Style/Semicolon
 #
@@ -5,7 +7,7 @@
 module DeepMerge
   class InvalidParameter < StandardError; end
 
-  DEFAULT_FIELD_KNOCKOUT_PREFIX = '--'.freeze
+  DEFAULT_FIELD_KNOCKOUT_PREFIX = '--'
 
   # Deep Merge core documentation.
   # deep_merge! method permits merging of arbitrary child elements. The two top level

--- a/lib/deep_merge/deep_merge.rb
+++ b/lib/deep_merge/deep_merge.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Totally borrowed from https://github.com/danielsdeleo/deep_merge
 require 'deep_merge/core'
 

--- a/sample/autoscale.rb
+++ b/sample/autoscale.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # We start things off by calling the CloudFormation function.
 CloudFormation do
   # Declare the template format version

--- a/sample/autoscale2.rb
+++ b/sample/autoscale2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # We start things off by calling the CloudFormation function.
 CloudFormation do
   # Declare the template format version

--- a/sample/circular.rb
+++ b/sample/circular.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 CloudFormation do
   AWSTemplateFormatVersion '2010-09-09'
 

--- a/sample/codedeploy.rb
+++ b/sample/codedeploy.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 CloudFormation do
-  DESCRIPTION ||= 'CodeDeploy description'.freeze
+  DESCRIPTION ||= 'CodeDeploy description'
 
   Description DESCRIPTION
 

--- a/sample/config_service.rb
+++ b/sample/config_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 CloudFormation do
   AWSTemplateFormatVersion '2010-09-09'
 

--- a/sample/ecs.rb
+++ b/sample/ecs.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 CloudFormation do
-  DESCRIPTION ||= 'ecs description'.freeze
+  DESCRIPTION ||= 'ecs description'
 
   Description DESCRIPTION
 

--- a/sample/export.rb
+++ b/sample/export.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 CloudFormation do
   EC2_SecurityGroup(:webSecurityGroup) do
     GroupDescription 'Allow incoming HTTP traffic from anywhere'

--- a/sample/iam_policies.rb
+++ b/sample/iam_policies.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 CloudFormation do
   AWSTemplateFormatVersion '2010-09-09'
 

--- a/sample/import.rb
+++ b/sample/import.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 CloudFormation do
   EC2_SecurityGroup(:databaseSecurityGroup) do
     GroupDescription 'Allow access from only web instances'

--- a/sample/lambda.rb
+++ b/sample/lambda.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 CloudFormation do
-  DESCRIPTION ||= 'lambda description'.freeze
+  DESCRIPTION ||= 'lambda description'
 
   Description DESCRIPTION
 

--- a/sample/s3.rb
+++ b/sample/s3.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 CloudFormation do
   S3_Bucket('Bucket') do
     BucketName 'MyBucket'

--- a/sample/t1.rb
+++ b/sample/t1.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 CloudFormation do
   description = external_parameters.fetch(:description, 'default description')
   machines = external_parameters.fetch(:machines, 1).to_i

--- a/sample/vpc_example.rb
+++ b/sample/vpc_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl'
 
 CloudFormation do

--- a/sample/vpc_with_vpn_example.rb
+++ b/sample/vpc_with_vpn_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cfndsl'
 
 CloudFormation do

--- a/spec/aws/ec2_security_group_spec.rb
+++ b/spec/aws/ec2_security_group_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::CloudFormationTemplate do

--- a/spec/aws/ecs_task_definition_spec.rb
+++ b/spec/aws/ecs_task_definition_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::CloudFormationTemplate do

--- a/spec/aws/iam_managed_policy_spec.rb
+++ b/spec/aws/iam_managed_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::CloudFormationTemplate do

--- a/spec/aws/kms_alias_spec.rb
+++ b/spec/aws/kms_alias_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::CloudFormationTemplate do

--- a/spec/aws/logs_log_group_spec.rb
+++ b/spec/aws/logs_log_group_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::CloudFormationTemplate do

--- a/spec/aws/nested_arrays_spec.rb
+++ b/spec/aws/nested_arrays_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::CloudFormationTemplate do

--- a/spec/aws/rds_db_instance_spec.rb
+++ b/spec/aws/rds_db_instance_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::CloudFormationTemplate do

--- a/spec/aws/serverless_spec.rb
+++ b/spec/aws/serverless_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 def read_json_fixture(filename)

--- a/spec/cfndsl_spec.rb
+++ b/spec/cfndsl_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl do

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-WORKING_SPEC_VERSION = '2.19.0'.freeze
+WORKING_SPEC_VERSION = '2.19.0'
 
 describe 'cfndsl', type: :aruba do
   let(:usage) do

--- a/spec/cloud_formation_template_spec.rb
+++ b/spec/cloud_formation_template_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::CloudFormationTemplate do

--- a/spec/deep_merge_spec.rb
+++ b/spec/deep_merge_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 describe DeepMerge do
   source = { key1: { keya1: 1, keya2: 2 }, key2: [1, 2] }

--- a/spec/external_parameters_spec.rb
+++ b/spec/external_parameters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::ExternalParameters do

--- a/spec/fixtures/heattest.rb
+++ b/spec/fixtures/heattest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Heat do
   Description 'Test'
 

--- a/spec/fixtures/test.rb
+++ b/spec/fixtures/test.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 CloudFormation do
-  TEST ||= 'no value set'.freeze
+  TEST ||= 'no value set'
   puts TEST
 
   Description external_parameters[:test]

--- a/spec/generate_spec.rb
+++ b/spec/generate_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 describe Cfnlego do
   let(:template) { Cfnlego.run(resources: ['AWS::EC2::EIP,EIP']) }

--- a/spec/heat_template_spec.rb
+++ b/spec/heat_template_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::HeatTemplate do

--- a/spec/jsonable_spec.rb
+++ b/spec/jsonable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::JSONable do

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'Metadata' do

--- a/spec/names_spec.rb
+++ b/spec/names_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl do

--- a/spec/output_spec.rb
+++ b/spec/output_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::OutputDefinition do

--- a/spec/plurals_spec.rb
+++ b/spec/plurals_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::Plurals do

--- a/spec/resources_spec.rb
+++ b/spec/resources_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe CfnDsl::ResourceDefinition do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aruba/rspec'
 
 if ENV['CFNDSL_COV']

--- a/spec/support/shared_examples/orchestration_template.rb
+++ b/spec/support/shared_examples/orchestration_template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples 'an orchestration template' do
   context '#valid_ref?' do
     it 'returns true if ref is global' do

--- a/spec/transform_spec.rb
+++ b/spec/transform_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'Transform' do

--- a/spec/types_definition_spec.rb
+++ b/spec/types_definition_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 # This is a somewhat temporary test class to compare functionality


### PR DESCRIPTION
Still one remaining:

`cfndsl.gemspec:19:29: C: Gemspec/RequiredRubyVersion: required_ruby_version (2.2, declared in cfndsl.gemspec) and TargetRubyVersion (2.3, which may be specified in .rubocop.yml) should be equal.`

Suggestion on fixing this?
