### PR TITLE
Added AWS Backup Specification and fix for uninitialized constant

### DIFF
--- a/lib/cfndsl/patches.rb
+++ b/lib/cfndsl/patches.rb
@@ -18,6 +18,26 @@ module CfnDsl
             'VpcId' => { 'PrimitiveType' => 'String' }
           }
         },
+        'AWS::Backup::BackupVault' => {
+          'Properties' => {
+            'BackupVaultName' => { 'PrimitiveType' => 'String' },
+            'BackupVaultTags' => { 'PrimitiveType' => 'Json' },
+            'EncryptionKeyArn' => { 'PrimitiveType' => 'String' },
+            'Notifications' => { 'PrimitiveType' => 'Json' }
+          }
+        },
+        'AWS::Backup::BackupPlan' => {
+          'Properties' => {
+            'BackupPlan' => { 'PrimitiveType' => 'Json' },
+            'BackupPlanTags' => { 'PrimitiveType' => 'Json' }
+          }
+        },
+        'AWS::Backup::BackupSelection' => {
+          'Properties' => {
+            'BackupPlanId' => { 'PrimitiveType' => 'String' },
+            'BackupSelection' => { 'PrimitiveType' => 'Json' }
+          }
+        },
         'AWS::CloudWatch::Alarm' => {
           'Properties' => {
             'ActionsEnabled' => { 'PrimitiveType' => 'Boolean' },
@@ -106,6 +126,12 @@ module CfnDsl
     def self.types
       {
         'AWS::EC2::LaunchTemplate.Tag' => {
+          'Properties' => {
+            'Value' => { 'PrimitiveType' => 'String' },
+            'Key' => { 'PrimitiveType' => 'String' }
+          }
+        },
+        'AWS::EC2::CapacityReservation.Tag' => {
           'Properties' => {
             'Value' => { 'PrimitiveType' => 'String' },
             'Key' => { 'PrimitiveType' => 'String' }

--- a/lib/cfndsl/patches.rb
+++ b/lib/cfndsl/patches.rb
@@ -20,6 +20,7 @@ module CfnDsl
         },
         'AWS::Backup::BackupVault' => {
           'Properties' => {
+            'AccessPolicy' => { 'PrimitiveType' => 'Json' },
             'BackupVaultName' => { 'PrimitiveType' => 'String' },
             'BackupVaultTags' => { 'PrimitiveType' => 'Json' },
             'EncryptionKeyArn' => { 'PrimitiveType' => 'String' },


### PR DESCRIPTION
Also fixing an issue with the latest AWS Cloudformation Spec:
```
/Users/steven.tan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/cfndsl-0.16.13/lib/cfndsl/types.rb:64:in `block (2 levels) in included': uninitialized constant CfnDsl::AWS::Types::AWSEC2CapacityReservationTag (NameError)
```