### PR TITLE
add ThroughputMode for EFS

### DIFF
--- a/lib/cfndsl/aws/types.yaml
+++ b/lib/cfndsl/aws/types.yaml
@@ -530,6 +530,7 @@ Resources:
    Properties:
     FileSystemTags : [ FileSystemTag ]
     PerformanceMode : String
+    ThroughputMode: String
   "AWS::EFS::MountTarget" :
    Properties:
     FileSystemId : String


### PR DESCRIPTION
Add Throughput mode for EFS. [Documentation for ThroughputMode can be found on the official docs](https://docs.aws.amazon.com/efs/latest/ug/performance.html).