### PR TITLE
add tag types to new WAFv2, as AWS are not explicitly defining them in the spec

### DIFF
--- a/cfndsl.gemspec
+++ b/cfndsl.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.executables << 'cfndsl'
 
-  s.add_development_dependency 'bundler', '~> 1.13'
+  s.add_development_dependency 'bundler', '~> 2.1'
 
   s.post_install_message = "'addTag' is now deprecated in favour of 'add_tag'. 'addTag' will be removed in the next major version."
 end

--- a/lib/cfndsl/patches.rb
+++ b/lib/cfndsl/patches.rb
@@ -126,6 +126,30 @@ module CfnDsl
     # rubocop:disable Metrics/MethodLength
     def self.types
       {
+        'AWS::WAFv2::IPSet.Tag' => {
+          'Properties' => {
+            'Value' => { 'PrimitiveType' => 'String' },
+            'Key' => { 'PrimitiveType' => 'String' }
+          }
+        },
+        'AWS::WAFv2::RegexPatternSet.Tag' => {
+          'Properties' => {
+            'Value' => { 'PrimitiveType' => 'String' },
+            'Key' => { 'PrimitiveType' => 'String' }
+          }
+        },
+        'AWS::WAFv2::RuleGroup.Tag' => {
+          'Properties' => {
+            'Value' => { 'PrimitiveType' => 'String' },
+            'Key' => { 'PrimitiveType' => 'String' }
+          }
+        },
+        'AWS::WAFv2::WebACL.Tag' => {
+          'Properties' => {
+            'Value' => { 'PrimitiveType' => 'String' },
+            'Key' => { 'PrimitiveType' => 'String' }
+          }
+        },
         'AWS::EC2::LaunchTemplate.Tag' => {
           'Properties' => {
             'Value' => { 'PrimitiveType' => 'String' },

--- a/spec/aws/nested_arrays_spec.rb
+++ b/spec/aws/nested_arrays_spec.rb
@@ -13,7 +13,6 @@ describe CfnDsl::CloudFormationTemplate do
         end
       end
 
-      puts template.to_json
       expect(template.to_json).to include('"SubnetIds":["subnet-a","subnet-b"]}')
       expect(template.to_json).not_to include('"SubnetIds":[["subnet-a","subnet-b"],["subnet-a","subnet-b"]]')
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,4 +20,4 @@ require 'cfnlego'
 bindir = File.expand_path('../bin', __dir__)
 ENV['PATH'] = [ENV['PATH'], bindir].join(':')
 
-Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
+Dir[File.expand_path('support/**/*.rb', __dir__)].sort.each { |f| require f }


### PR DESCRIPTION
fixes #430 