### PR TITLE
Added support for AWS::Partition pseudo parameter

### DIFF
--- a/lib/cfndsl/orchestration_template.rb
+++ b/lib/cfndsl/orchestration_template.rb
@@ -32,7 +32,8 @@ module CfnDsl
       'AWS::StackName' => 1,
       'AWS::AccountId' => 1,
       'AWS::NoValue' => 1,
-      'AWS::URLSuffix' => 1
+      'AWS::URLSuffix' => 1,
+      'AWS::Partition' => 1
     }.freeze
 
     class << self

--- a/spec/cfndsl_spec.rb
+++ b/spec/cfndsl_spec.rb
@@ -166,7 +166,8 @@ describe CfnDsl::CloudFormationTemplate do
       'AWS::Region',
       'AWS::StackId',
       'AWS::StackName',
-      'AWS::URLSuffix'
+      'AWS::URLSuffix',
+      'AWS::Partition'
     ].each do |param|
       ref = subject.Ref param
       expect(ref.to_json).to eq("{\"Ref\":\"#{param}\"}")

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -71,7 +71,7 @@ Specification ([0-9]+\.){2}[0-9]+ successfully written to #{ENV['HOME']}/.cfndsl
 
   context 'cfndsl' do
     it 'displays the usage' do
-      run_command'cfndsl'
+      run_command 'cfndsl'
       expect(last_command_started).to have_output(usage)
       expect(last_command_started).to have_exit_status(1)
     end


### PR DESCRIPTION
This should fix #444.

However the spec does not fail when it should. For example, if you make this modification:

```
  it 'handles pseudo parameters' do
    [
      'AWS::AccountId',
      'AWS::NotificationARNs',
      'AWS::NoValue',
      'AWS::Region',
      'AWS::StackId',
      'AWS::StackName',
      'AWS::URLSuffix',
      'AWS::ScoobyDoobyDoo' # <--
    ].each do |param|
      ref = subject.Ref param
      expect(ref.to_json).to eq("{\"Ref\":\"#{param}\"}")
      refs = ref.build_references
      expect(refs).to include(param)
    end
  end
```

It will still pass.

Fixes #444.

