### PR TITLE
Support composeable DependsOn

### DIFF
--- a/lib/cfndsl/resources.rb
+++ b/lib/cfndsl/resources.rb
@@ -5,7 +5,7 @@ require_relative 'jsonable'
 module CfnDsl
   # Handles Resource objects
   class ResourceDefinition < JSONable
-    dsl_attr_setter :Type, :DependsOn, :UpdateReplacePolicy, :DeletionPolicy, :Condition, :Metadata
+    dsl_attr_setter :Type, :UpdateReplacePolicy, :DeletionPolicy, :Condition, :Metadata
     dsl_content_object :Property, :UpdatePolicy, :CreationPolicy
 
     def add_tag(name, value, propagate = nil)
@@ -14,6 +14,23 @@ module CfnDsl
         Value value
         PropagateAtLaunch propagate unless propagate.nil?
       end
+    end
+
+    # DependsOn can be a single value or a list
+    def DependsOn(value)
+      case @DependsOn
+      when nil
+        @DependsOn = value
+      when Array
+        @DependsOn << value
+      else
+        @DependsOn = [@DependsOn, value]
+      end
+      if @DependsOn.is_a?(Array)
+        @DependsOn.flatten!
+        @DependsOn.uniq!
+      end
+      @DependsOn
     end
 
     def condition_refs

--- a/spec/cfndsl_spec.rb
+++ b/spec/cfndsl_spec.rb
@@ -188,6 +188,26 @@ describe CfnDsl::CloudFormationTemplate do
     end
   end
 
+  it 'composes DependsOn' do
+    spec = self
+    subject.Resource('SomeResource') do
+      d = DependsOn('X')
+      spec.expect(d).to spec.eq('X') # start with a single value, stays a single value
+      d = DependsOn(%w[Y Z])
+      spec.expect(d).to spec.eq(%w[X Y Z]) # concatenates values
+      d = DependsOn('Y') # uniqeness
+      spec.expect(d).to spec.eq(%w[X Y Z])
+    end
+    expect(subject.to_json).to eq('{"AWSTemplateFormatVersion":"2010-09-09","Resources":{"SomeResource":{"DependsOn":["X","Y","Z"]}}}')
+  end
+
+  it 'supports single value DependsOn' do
+    subject.Resource('SomeResource') do
+      DependsOn(:ADependency)
+    end
+    expect(subject.to_json).to eq('{"AWSTemplateFormatVersion":"2010-09-09","Resources":{"SomeResource":{"DependsOn":"ADependency"}}}')
+  end
+
   context 'built-in functions' do
     it 'FnGetAtt' do
       func = subject.FnGetAtt('A', 'B')

--- a/spec/cloud_formation_template_spec.rb
+++ b/spec/cloud_formation_template_spec.rb
@@ -64,6 +64,7 @@ describe CfnDsl::CloudFormationTemplate do
         tr = subject.Resource(:TestResource)
         tr.Type('Custom-TestType')
         tr.DependsOn(:TestResource2)
+        tr.DependsOn(:TestResource2)
 
         t2 = subject.Resource('TestResource2')
         t2.Type('Custom-TestType')


### PR DESCRIPTION
fixes #63

Note this will require at least a minor version update as templates that are inadvertently calling DependsOn twice will now concatenate values instead of replacing them.

Depends on #462 