### PR TITLE
enable resource version 22.0.0, some type processing fixes

### DIFF
--- a/lib/cfndsl/aws/patches/900_SageMakerTags_patch.json
+++ b/lib/cfndsl/aws/patches/900_SageMakerTags_patch.json
@@ -1,0 +1,41 @@
+{
+  "broken": "22.0.0",
+  "ResourceTypes": {
+    "AWS::SageMaker::Device": {
+      "patch": {
+        "operations": [
+          {
+            "op": "replace",
+            "path": "/Properties/Tags",
+            "value": {
+              "Type": "List",
+              "ItemType": "Tag",
+              "Required": false,
+              "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-device.html#cfn-sagemaker-device-tags",
+              "UpdateType": "Mutable"
+            }
+          }
+        ],
+        "description": "Fix SageMaker Device to be List of Tag"
+      }
+    },
+    "AWS::SageMaker::DeviceFleet": {
+      "patch": {
+        "operations": [
+          {
+            "op": "replace",
+            "path": "/Properties/Tags",
+            "value": {
+              "Type": "List",
+              "ItemType": "Tag",
+              "Required": false,
+              "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-device.html#cfn-sagemaker-device-tags",
+              "UpdateType": "Mutable"
+            }
+          }
+        ],
+        "description": "Fix SageMaker Device to be List of Tag"
+      }
+    }
+  }
+}

--- a/lib/cfndsl/types.rb
+++ b/lib/cfndsl/types.rb
@@ -43,7 +43,8 @@ module CfnDsl
             # resource name for uniqueness and connection
             property_type = resource_name.split('::').join + property_info['Type']
           else
-            warn "could not extract resource type from #{resource_name}"
+            warn "could not extract resource type for property #{property_name} from #{resource_name}, assuming Json"
+            property_type = 'Json'
           end
           extracted[property_name] = property_type
           extracted
@@ -99,6 +100,8 @@ module CfnDsl
               nested_prop_type =
                 if nested_prop_info['ItemType'] == 'Tag'
                   ['Tag']
+                elsif nested_prop_info['ItemType'] == 'Json' and nested_prop_info['Type'] == 'List'
+                  ['Json']
                 else
                   Array(root_resource_name + nested_prop_info['ItemType'])
                 end
@@ -106,7 +109,8 @@ module CfnDsl
             elsif nested_prop_info['Type']
               nested_prop_type = root_resource_name + nested_prop_info['Type']
             else
-              warn "could not extract property type from #{property_name}"
+              warn "could not extract property type for #{nested_prop_name} from #{property_name}, assuming Json"
+              nested_prop_type = 'Json'
               p nested_prop_info
             end
             extracted[nested_prop_name] = nested_prop_type


### PR DESCRIPTION
## Problem

`cfndsl` fails with latest resource specification (test below) 

```
$ docker run --rm -it ruby:2.7-alpine sh
$ gem install cfndsl
$ cfndsl -u 
$ cat << EOT >> template.cfndsl.rb
CfhighlanderTemplate do
   S3_Bucket(:Bucket) do
   end
end
EOT
$ cfndsl template.cfndsl.rb

unknown type 
unknown type 
unknown type 
unknown type 
unknown type AWSSageMakerDeviceFleetJson
unknown type AWSSageMakerDeviceJson
Traceback (most recent call last):
	19: from /usr/local/bundle/bin/cfndsl:23:in `<main>'
	18: from /usr/local/bundle/bin/cfndsl:23:in `load'
	17: from /usr/local/bundle/gems/cfndsl-1.2.0/exe/cfndsl:5:in `<top (required)>'
	16: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/runner.rb:124:in `invoke!'
	15: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/runner.rb:124:in `require_relative'
	14: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/cloudformation.rb:5:in `<top (required)>'
	13: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/cloudformation.rb:5:in `require_relative'
	12: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/aws/cloud_formation_template.rb:4:in `<top (required)>'
	11: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/aws/cloud_formation_template.rb:4:in `require_relative'
	10: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/aws/types.rb:6:in `<top (required)>'
	 9: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/aws/types.rb:7:in `<module:CfnDsl>'
	 8: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/aws/types.rb:9:in `<module:AWS>'
	 7: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/aws/types.rb:11:in `<module:Types>'
	 6: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/aws/types.rb:11:in `include'
	 5: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/types.rb:165:in `included'
	 4: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/types.rb:165:in `each_pair'
	 3: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/types.rb:169:in `block in included'
	 2: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/types.rb:169:in `each_pair'
	 1: from /usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/types.rb:186:in `block (2 levels) in included'
/usr/local/bundle/gems/cfndsl-1.2.0/lib/cfndsl/types.rb:186:in `const_get': no implicit conversion of nil into String (TypeError)
```

## Fix 

- Apply patch for `AWS::SageMaker::Device` and `AWS::SageMaker::DeviceFleet` property `Tags` 
- There are few properties that do not have type defined in documentation. Fallback to `Json` for these, as types loading process breaks otherwise. Example of such property is `SpeekKeyProvider` for [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-mediapackage-packagingconfiguration-dashencryption.html](AWS::MediaPackage::PackagingConfiguration DashEncryption) resource
  This applies both for resource and sub-types properties. 

- `AWS::Iot::Authorizer.Tags` is one example of  `Type=List;ItemType=Json` property. While valid, code did not cater for such use-case till now

## Testing

Tests seem to run just fine, but `rubocop` reports heaps of irregularities, not related to lines changed though. Travis seems to be failing with completely unrelated error, so would probably need some guidance to get tests to `exit 0`

```
$ docker run -v $PWD:/src -w/src --rm -it ruby:2.6 sh
# gem install bundler
# bundle install
# bundle exec rake
```

Output

```
/usr/local/bin/ruby -I/usr/local/bundle/gems/rspec-core-3.10.0/lib:/usr/local/bundle/gems/rspec-support-3.10.0/lib /usr/local/bundle/gems/rspec-core-3.10.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
.................................no value set

Finished in 43.87 seconds (files took 3.4 seconds to load)
2062 examples, 0 failures



Running RuboCop...
Inspecting 81 files
...........WW....WWC.WWWCWW..WCCCW.C.....W.......CC..........W...................


81 files inspected, 44 offenses detected, 22 offenses auto-correctable


```


