### PR TITLE
Allow running on Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
 - 2.7
+- '3.0'
 sudo: false
 before_install:
   - gem update --system

--- a/cfndsl.gemspec
+++ b/cfndsl.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files            = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths         = ['lib']
   s.bindir                = 'exe'
-  s.required_ruby_version = '~> 2.7'
+  s.required_ruby_version = '>= 2.7'
 
   s.executables << 'cfndsl'
 


### PR DESCRIPTION
### Context

The gem currently allows Running on Ruby `~> 2.7` (expanded: `>= 2.7.0, < 3.0.0`). This makes it unavailable for use on the recently released [Ruby 3.0.0](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/).

### Change

Allow running the gem on Ruby 3.0 by removing the upper bound.

### Considerations

The test suite passes for me on Ruby 3.0.
