### PR TITLE
Fix for cfndsl list command, undefined method 'Resources'

### DIFF
--- a/lib/cfndsl/runner.rb
+++ b/lib/cfndsl/runner.rb
@@ -76,7 +76,7 @@ module CfnDsl
 
         opts.on('-l', '--list', 'List supported resources') do
           require_relative 'cfnlego'
-          puts Cfnlego.Resources.sort
+          puts Cfnlego.resources.sort
           exit
         end
 


### PR DESCRIPTION
cfndsl -l or cfndsl --list command is failing with error message undefined method `Resources' for Cfnlego:Module (NoMethodError)

cfndsl -l
Traceback (most recent call last):
        10: from /usr/local/bin/cfndsl:23:in `<main>'
         9: from /usr/local/bin/cfndsl:23:in `load'
         8: from /var/lib/gems/2.7.0/gems/cfndsl-1.3.6/exe/cfndsl:5:in `<top (required)>'
         7: from /var/lib/gems/2.7.0/gems/cfndsl-1.3.6/lib/cfndsl/runner.rb:92:in `invoke!'
         6: from /usr/lib/ruby/2.7.0/optparse.rb:1691:in `parse!'
         5: from /usr/lib/ruby/2.7.0/optparse.rb:1666:in `permute!'
         4: from /usr/lib/ruby/2.7.0/optparse.rb:1569:in `order!'
         3: from /usr/lib/ruby/2.7.0/optparse.rb:1575:in `parse_in_order'
         2: from /usr/lib/ruby/2.7.0/optparse.rb:1575:in `catch'
         1: from /usr/lib/ruby/2.7.0/optparse.rb:1621:in `block in parse_in_order'
/var/lib/gems/2.7.0/gems/cfndsl-1.3.6/lib/cfndsl/runner.rb:79:in `block (2 levels) in invoke!': undefined method `Resources' for Cfnlego:Module (NoMethodError)
Did you mean?  rescue
