### PR TITLE
Add back a piece removed years ago when cleaning

### DIFF
--- a/lib/cfndsl/cloudformation.rb
+++ b/lib/cfndsl/cloudformation.rb
@@ -54,6 +54,10 @@ module CfnDsl
       end
     end
 
+    params.each_pair do |k, v|
+      b.eval "#{k} = #{v.inspect}"
+    end
+
     logstream.puts("Loading template file #{filename}") if logstream
     b.eval(File.read(filename), filename)
   end


### PR DESCRIPTION
Someone accidentally removed this back in the changes after 0.16 and it's been broken for some time. The variables pulled in by the extras were never actually used in the binding and just ignored by the method. This adds back the required piece to actually use the extras being parsed by the eval_file_with_extras method as the name implies.