### PR TITLE
Update CloudFormation specification to v237.0.0

### DIFF
--- a/lib/cfndsl/aws/patches/500_IPAMPrefixListResolver_Tag_patch.json
+++ b/lib/cfndsl/aws/patches/500_IPAMPrefixListResolver_Tag_patch.json
@@ -1,0 +1,30 @@
+{
+  "broken": "237.0.0",
+  "PropertyTypes": {
+    "patch": {
+      "operations": [
+        {
+          "op": "add",
+          "path": "/AWS::EC2::IPAMPrefixListResolver.Tag",
+          "value": {
+            "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ipamprefixlistresolver-tag.html",
+            "Properties": {
+              "Key": {
+                "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ipamprefixlistresolver-tag.html#cfn-ec2-ipamprefixlistresolver-tag-key",
+                "UpdateType": "Mutable",
+                "Required": true,
+                "PrimitiveType": "String"
+              },
+              "Value": {
+                "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ipamprefixlistresolver-tag.html#cfn-ec2-ipamprefixlistresolver-tag-value",
+                "UpdateType": "Mutable",
+                "Required": true,
+                "PrimitiveType": "String"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- Update resource specification to version 237.0.0
- Add patch for missing AWS::EC2::IPAMPrefixListResolver.Tag type definition