### PR TITLE
Update AWS specification URL to us-west-2 distribution

### DIFF
--- a/lib/cfndsl/globals.rb
+++ b/lib/cfndsl/globals.rb
@@ -10,7 +10,7 @@ module CfnDsl
 
   module_function
 
-  AWS_SPECIFICATION_URL = 'https://d1uauaxba7bl26.cloudfront.net/%<version>s/gzip/CloudFormationResourceSpecification.json'
+  AWS_SPECIFICATION_URL = 'https://d201a2mn26r7lk.cloudfront.net/%<version>s/gzip/CloudFormationResourceSpecification.json'
   LOCAL_SPEC_FILE = File.expand_path('aws/resource_specification.json', __dir__)
 
   def disable_deep_merge


### PR DESCRIPTION
### Fix cfndsl -u VERSION by switching spec download to us-west-2

Pinning a version with cfndsl -u x.y.z started failing recently.

Turns out AWS stopped serving versioned spec files from the us-east-1 CloudFront URL we were using. latest still works there, but anything like /11.5.0/gzip/... comes back 404. us-west-2 still has all the versioned specs, so this PR just points the download URL at that distribution instead.

#### failing  (us-east-1: old default)
https://d1uauaxba7bl26.cloudfront.net/11.5.0/gzip/CloudFormationResourceSpecification.json

#### working (us-west-2: new default)
https://d201a2mn26r7lk.cloudfront.net/11.5.0/gzip/CloudFormationResourceSpecification.json

Could also add a --specification-region flag later if other regions start removing the versioned assets.