### PR TITLE
Add fixed version ceiling to unbounded patch files

### DIFF
--- a/lib/cfndsl/aws/patches/500_BadTagsv13.0.0_patch.json
+++ b/lib/cfndsl/aws/patches/500_BadTagsv13.0.0_patch.json
@@ -1,5 +1,6 @@
 {
   "broken": "13.0.0",
+  "fixed": "254.0.0",
   "ResourceTypes": {
     "AWS::ResourceGroups::Group": {
       "patch": {

--- a/lib/cfndsl/aws/patches/500_BadTagsv16.2.0_patch.json
+++ b/lib/cfndsl/aws/patches/500_BadTagsv16.2.0_patch.json
@@ -1,5 +1,6 @@
 {
   "broken": "16.2.0",
+  "fixed": "237.0.0",
   "ResourceTypes": {
     "AWS::IoT::ProvisioningTemplate": {
       "patch": {


### PR DESCRIPTION
Fixes #501.

## Summary

Two patch files lacked a `"fixed"` version ceiling, causing them to apply unconditionally on every spec version. When the upstream CloudFormation spec removed the patched targets, this caused `Hana::Patch::MissingTargetException` on every spec load.

## Changes

- **500_BadTagsv13.0.0_patch.json**: Added `"fixed": "254.0.0"`
  - The `AWS::CloudWatch::InsightRule.Tags` PropertyType was removed in spec v254
  - Patch now correctly skips for spec versions ≥ 254

- **500_BadTagsv16.2.0_patch.json**: Added `"fixed": "237.0.0"`
  - The `IoT::ProvisioningTemplate` Tags property already has the correct `List/Tag` definition by v237
  - Patch was a harmless no-op but is now correctly scoped

## Testing

Verified patches behave correctly across the version boundary:
- v237: patches apply correctly ✓
- v253: patches apply correctly ✓  
- v254: v13 patch skipped (target removed), v16 patch already skipped ✓
- v255: both patches skipped ✓

Full test suite passes at all versions (10679 examples, 0 failures).