### PR TITLE
ci: run spec workflow on pull requests

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "**"
+  pull_request:
 env:
   BUNDLE_FROZEN: "true"
 jobs:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -17,7 +17,7 @@ jobs:
         ruby-version: ['2.7', '3.1', '3.2', '3.3', '3.4']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/spec_latest.yml
+++ b/.github/workflows/spec_latest.yml
@@ -1,0 +1,23 @@
+name: CFN Nightly
+
+on:
+  schedule:
+    - cron: '42 1 * * *' # ~11:42am AEST / 12:42pm AEDT
+  workflow_dispatch:
+
+jobs:
+  test-latest-spec:
+    if: github.repository == 'cfndsl/cfndsl' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+      - name: Update to latest CloudFormation spec
+        run: bundle exec rake "update_cfn_spec[latest]"
+      - name: Run tests
+        run: bundle exec rspec

--- a/.github/workflows/spec_publish.yml
+++ b/.github/workflows/spec_publish.yml
@@ -14,7 +14,7 @@ jobs:
         ruby-version: ['3.1']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ cfndsl
 ======
 
 [![Spec](https://github.com/cfndsl/cfndsl/actions/workflows/spec.yml/badge.svg)](https://github.com/cfndsl/cfndsl/actions/workflows/spec.yml)
+[![CFN Nightly](https://github.com/cfndsl/cfndsl/actions/workflows/spec_latest.yml/badge.svg)](https://github.com/cfndsl/cfndsl/actions/workflows/spec_latest.yml)
 [![Gem Version](https://badge.fury.io/rb/cfndsl.png)](http://badge.fury.io/rb/cfndsl)
 
 [AWS Cloudformation](http://docs.amazonwebservices.com/AWSCloudFormation/latest/UserGuide/GettingStarted.html) templates are an incredibly powerful way to build


### PR DESCRIPTION
Adds a `pull_request` trigger to the Spec workflow so tests run automatically on PRs.

Adds a nightly job and README badge to validate against the latest upstream Cloudformation Specification